### PR TITLE
chore: mobile updates ui

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
       font-family: 'Questrial', sans-serif;
       -webkit-font-smoothing: antialiased;
       min-height: 100vh;
+      overflow-x: hidden;
     }
 
     nav {
@@ -358,8 +359,8 @@
 
     @media (max-width: 600px) {
       .oss { padding: 0 1.5rem 6rem; }
-      .oss-row { grid-template-columns: 1fr auto; gap: 0.25rem 1rem; }
-      .oss-repo { display: none; }
+      .oss-row { grid-template-columns: 40px 1fr auto; gap: 0.5rem 0.75rem; }
+      .oss-repo img { width: 36px; height: 36px; }
     }
 
     /* ─── GLYPH STRIP ─── */
@@ -384,11 +385,11 @@
 
     @media (max-width: 600px) {
       nav { padding: 1.75rem 1.5rem; }
-      .nav-links { gap: 1.25rem; }
-      .nav-links a { font-size: 0.82rem; }
-      .nav-contact { display: none; }
+      .nav-links { gap: 0.75rem; }
+      .nav-links a { font-size: 0.8rem; }
+      .nav-contact { font-size: 0.72rem; padding: 0.35rem 0.75rem; }
       .hero { padding: 3.5rem 1.5rem 6rem; }
-      .hero-body { margin-top: 2.5rem; }
+      .hero-body { margin-top: 2.5rem; max-width: 100%; }
       .glyph-strip { grid-template-columns: repeat(2, 1fr); height: auto; margin-bottom: 4rem; }
       .glyph-panel { height: 150px; }
       .work { padding: 0 1.5rem 6rem; }
@@ -396,7 +397,7 @@
       .work-item:nth-child(even) { padding-left: 0; border-left: none; }
       .writing { padding: 0 1.5rem 8rem; }
       .writing-grid { grid-template-columns: 1fr; }
-      .writing-item { aspect-ratio: 3 / 2; }
+      .writing-item { aspect-ratio: 3 / 2; padding: 1.25rem; }
     }
   </style>
 </head>

--- a/writing/index.html
+++ b/writing/index.html
@@ -203,12 +203,14 @@
 
     @media (max-width: 600px) {
       nav { padding: 1.75rem 1.5rem; }
-      .nav-links { gap: 1.5rem; }
-      .nav-links a { font-size: 0.82rem; }
+      .nav-links { gap: 0.75rem; }
+      .nav-links a { font-size: 0.8rem; }
+      .nav-contact { font-size: 0.72rem; padding: 0.35rem 0.75rem; }
       .hero { padding: 3rem 1.5rem 2.5rem; }
-      .tag-filter { padding: 0 1.5rem 2rem; }
+      .hero-sub { max-width: 100%; }
+      .tag-filter { padding: 0 1.5rem 2rem; gap: 0.35rem 0.85rem; }
       .post-list { padding: 0 1.5rem 8rem; }
-      .post-row { grid-template-columns: 52px 1fr; gap: 0 1rem; padding: 1.5rem 0; }
+      .post-row { grid-template-columns: 48px 1fr; gap: 0 0.85rem; padding: 1.25rem 1rem; }
     }
   </style>
 </head>


### PR DESCRIPTION
  Mobile UI fixes — index + writing pages

  - Horizontal overflow (index.html): Added overflow-x: hidden to body and max-width: 100% to .hero-body to prevent the 54ch
  constraint from pushing the page wider than the viewport on ~375px screens
  - Contact button (both pages): Was hidden with display: none on mobile — now visible with tighter sizing (0.72rem / compact
  padding), nav gap tightened to fit everything on one line
  - Open Source logos (index.html): .oss-repo was display: none on mobile — restored with updated grid (40px 1fr auto) and
  36px image sizing
  - Writing cards (index.html): Reduced inner padding from 2rem to 1.25rem on mobile so full-width cards don't feel too
  sprawling
  - Writing list (writing/index.html): Post row padding was 1.5rem 0 (no horizontal padding), causing content to sit flush
  against card edges — restored to 1.25rem 1rem. Tag filter gap tightened so all tags fit on one row. hero-sub gets max-width:
   100% override

  Test

  Verified on iPhone (375px portrait) in Safari.