### PR TITLE
Chore/UI cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -565,6 +565,15 @@
 <section class="oss">
   <p class="oss-label">Open Source</p>
 
+  <a href="https://github.com/spotify/confidence-sdk-python/issues/114" target="_blank" rel="noopener" class="oss-row">
+    <span class="oss-repo"><img src="https://github.com/spotify.png?size=80" alt="confidence-sdk-python" /></span>
+    <div>
+      <p class="oss-title">Found shared mutable class-level context causing instance data leakage</p>
+      <p class="oss-desc">All <code>Confidence</code> instances shared the same class-level <code>context</code> dict — setting context on one silently contaminated all others. Identified the root cause, proposed moving initialization to <code>__init__</code>, and flagged a secondary risk with a shared <code>httpx.AsyncClient</code>.</p>
+    </div>
+    <span class="oss-status">Closed ↗</span>
+  </a>
+
   <a href="https://github.com/gocardless/gocardless-pro-python/issues/129" target="_blank" rel="noopener" class="oss-row">
     <span class="oss-repo"><img src="https://github.com/gocardless.png?size=80" alt="gocardless-pro-python" /></span>
     <div>
@@ -579,15 +588,6 @@
     <div>
       <p class="oss-title">Added direct unit tests for the Paginator class</p>
       <p class="oss-desc">The <code>Paginator</code> class powers every <code>.all()</code> call in the library but had zero direct coverage. Added 7 isolated unit tests with <code>unittest.mock</code> covering multi-page traversal, cursor logic, parameter passing, empty responses, and mutation safety.</p>
-    </div>
-    <span class="oss-status">Closed ↗</span>
-  </a>
-
-  <a href="https://github.com/spotify/confidence-sdk-python/issues/114" target="_blank" rel="noopener" class="oss-row">
-    <span class="oss-repo"><img src="https://github.com/spotify.png?size=80" alt="confidence-sdk-python" /></span>
-    <div>
-      <p class="oss-title">Found shared mutable class-level context causing instance data leakage</p>
-      <p class="oss-desc">All <code>Confidence</code> instances shared the same class-level <code>context</code> dict — setting context on one silently contaminated all others. Identified the root cause, proposed moving initialization to <code>__init__</code>, and flagged a secondary risk with a shared <code>httpx.AsyncClient</code>.</p>
     </div>
     <span class="oss-status">Closed ↗</span>
   </a>

--- a/writing/cicd-same-image.html
+++ b/writing/cicd-same-image.html
@@ -245,8 +245,11 @@
 
     @media (max-width: 600px) {
       nav { padding: 1.75rem 1.5rem; }
-      .nav-links { gap: 1.5rem; }
-      .nav-links a { font-size: 0.82rem; }
+      .nav-links { gap: 0.75rem; }
+      .nav-links a { font-size: 0.8rem; }
+      .nav-contact { font-size: 0.72rem; padding: 0.35rem 0.75rem; }
+      .nav-linkedin svg { width: 16px; height: 16px; }
+      .nav-theme-toggle { display: none; }
       .post-wrap { padding: 2.5rem 1.25rem 6rem; }
       .post-body { font-size: 0.96rem; }
     }

--- a/writing/htmx-production.html
+++ b/writing/htmx-production.html
@@ -245,8 +245,11 @@
 
     @media (max-width: 600px) {
       nav { padding: 1.75rem 1.5rem; }
-      .nav-links { gap: 1.5rem; }
-      .nav-links a { font-size: 0.82rem; }
+      .nav-links { gap: 0.75rem; }
+      .nav-links a { font-size: 0.8rem; }
+      .nav-contact { font-size: 0.72rem; padding: 0.35rem 0.75rem; }
+      .nav-linkedin svg { width: 16px; height: 16px; }
+      .nav-theme-toggle { display: none; }
       .post-wrap { padding: 2.5rem 1.25rem 6rem; }
       .post-body { font-size: 0.96rem; }
     }

--- a/writing/overengineering-operational-exhaustion.html
+++ b/writing/overengineering-operational-exhaustion.html
@@ -245,8 +245,11 @@
 
     @media (max-width: 600px) {
       nav { padding: 1.75rem 1.5rem; }
-      .nav-links { gap: 1.5rem; }
-      .nav-links a { font-size: 0.82rem; }
+      .nav-links { gap: 0.75rem; }
+      .nav-links a { font-size: 0.8rem; }
+      .nav-contact { font-size: 0.72rem; padding: 0.35rem 0.75rem; }
+      .nav-linkedin svg { width: 16px; height: 16px; }
+      .nav-theme-toggle { display: none; }
       .post-wrap { padding: 2.5rem 1.25rem 6rem; }
       .post-body { font-size: 0.96rem; }
     }

--- a/writing/partida-gap.html
+++ b/writing/partida-gap.html
@@ -245,8 +245,11 @@
 
     @media (max-width: 600px) {
       nav { padding: 1.75rem 1.5rem; }
-      .nav-links { gap: 1.5rem; }
-      .nav-links a { font-size: 0.82rem; }
+      .nav-links { gap: 0.75rem; }
+      .nav-links a { font-size: 0.8rem; }
+      .nav-contact { font-size: 0.72rem; padding: 0.35rem 0.75rem; }
+      .nav-linkedin svg { width: 16px; height: 16px; }
+      .nav-theme-toggle { display: none; }
       .post-wrap { padding: 2.5rem 1.25rem 6rem; }
       .post-body { font-size: 0.96rem; }
     }

--- a/writing/terraform-dishwasher.html
+++ b/writing/terraform-dishwasher.html
@@ -245,8 +245,11 @@
 
     @media (max-width: 600px) {
       nav { padding: 1.75rem 1.5rem; }
-      .nav-links { gap: 1.5rem; }
-      .nav-links a { font-size: 0.82rem; }
+      .nav-links { gap: 0.75rem; }
+      .nav-links a { font-size: 0.8rem; }
+      .nav-contact { font-size: 0.72rem; padding: 0.35rem 0.75rem; }
+      .nav-linkedin svg { width: 16px; height: 16px; }
+      .nav-theme-toggle { display: none; }
       .post-wrap { padding: 2.5rem 1.25rem 6rem; }
       .post-body { font-size: 0.96rem; }
     }


### PR DESCRIPTION
  Dark mode support, Spotify OSS contribution, and mobile nav fixes across all pages.

  - Added dark mode toggle (CSS variables + JS) with system preference detection and localStorage persistence across all 8
  pages
  - Added a Spotify OSS contribution entry to the homepage
  - Fixed mobile nav overflow on individual blog post pages — reduced link gap, shrunk contact button and LinkedIn icon, and
  hid the theme toggle at ≤600px to match the homepage behavior