### PR TITLE
feat: redesign hero, unify site typography/spacing, and polish nav

### DIFF
--- a/about.html
+++ b/about.html
@@ -72,6 +72,12 @@
       gap: 28px;
     }
 
+    .header-controls {
+      display: flex;
+      align-items: center;
+      gap: 28px;
+    }
+
     nav a {
       color: var(--muted);
       text-decoration: none;
@@ -79,9 +85,13 @@
       font-weight: 200;
     }
 
-    nav a:hover,
+    nav a:hover {
+      color: var(--ink);
+    }
+
     nav a.active {
       color: var(--ink);
+      font-weight: 600;
     }
 
     .theme-toggle {
@@ -153,8 +163,8 @@
         padding: 12px 0;
       }
 
-      nav .theme-toggle {
-        margin-top: 8px;
+      .header-controls {
+        gap: 12px;
       }
     }
 
@@ -224,12 +234,11 @@
       margin-top: 56px;
     }
 
-    .section-label {
-      font-size: 13px;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      color: var(--muted);
+    .about-heading {
+      font-size: 20px;
+      font-weight: 700;
+      letter-spacing: -0.005em;
+      color: var(--ink);
       margin: 0 0 16px;
     }
 
@@ -256,6 +265,7 @@
     .connect-list {
       display: flex;
       flex-direction: column;
+      gap: 4px;
     }
 
     .connect-list a {
@@ -265,16 +275,11 @@
       padding: 14px 10px;
       margin: 0 -10px;
       border-radius: 8px;
-      border-bottom: 1px solid var(--border);
       color: var(--ink);
       font-size: 16px;
       font-weight: 600;
       text-decoration: none;
       transition: background-color 0.2s ease;
-    }
-
-    .connect-list a:last-child {
-      border-bottom: none;
     }
 
     .connect-list a:hover {
@@ -387,22 +392,24 @@
     <a href="index.html" class="brand-name">Austin Edmonson</a>
   </div>
 
-  <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-  </button>
-
-  <nav id="siteNav">
-    <a href="index.html">Home</a>
+  <div class="header-controls">
+    <nav id="siteNav">
     <a href="writing/index.html">Articles</a>
     <a href="about.html" class="active">About</a>
     <a href="projects/index.html">Projects</a>
     <a href="uses.html">Uses</a>
+    </nav>
+
     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
       </svg>
     </button>
-  </nav>
+
+    <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+  </div>
 </header>
 
 <main>
@@ -410,10 +417,10 @@
     <h1 class="about-headline">I'm Austin. I build internal platforms that make thousands of engineers faster.</h1>
     <img src="assets/austin-headshot.jpeg" alt="Austin Edmonson" class="about-avatar" />
   </div>
-  <p class="about-bio">6+ years across DevOps, platform engineering, and software engineering. Self-taught but not self-made. I have benefitted from working with brilliant engineers and managers throughout my career - and learning alongside them. I collaborate across teams exceptionally well and I thrive in ambiguity and drive results. Started as a DevOps intern at Shadow Soft, moved into a Systems Engineer role at Acoustic AI, then joined The Home Depot, where I now own end-to-end CI/CD pipeline architecture for a 3,000+ developer organization. Alongside that, I'm the sole founder and developer of Partida, an immigration case management platform for families relocating to Portugal.</p>
+  <p class="about-bio">6+ years across DevOps, platform engineering, and software engineering. Self-taught but not self-made. I have benefitted from working with brilliant engineers and managers throughout my career - and learning alongside them. I collaborate across teams exceptionally well and I thrive in ambiguity and drive results. Started as a DevOps intern at Shadow Soft, moved into a Systems Engineer role at Acoustic AI, then joined The Home Depot, where I now own end-to-end CI/CD pipeline architecture for a 5,000+ developer organization. Alongside that, I'm the sole founder and developer of Partida, an immigration case management platform for families relocating to Portugal.</p>
 
   <section class="how-i-work">
-    <p class="section-label">How I Work</p>
+    <h2 class="about-heading">How I Work</h2>
     <ul class="philosophy-list">
       <li><strong>Self-taught, by necessity.</strong> I'm good at finding the right resource, making sense of it fast, and turning unclear problems into working systems.</li>
       <li><strong>AI as a multiplier, not a shortcut.</strong> Claude and Copilot compress the time it takes to get from ambiguity to clarity — the engineering judgment still has to be mine.</li>
@@ -423,7 +430,7 @@
   </section>
 
   <section class="connect">
-    <p class="section-label">Connect</p>
+    <h2 class="about-heading">Connect</h2>
     <div class="connect-list">
       <a href="https://linkedin.com/in/abedmonson" target="_blank" rel="noopener">
         <svg viewBox="0 0 24 24" fill="currentColor"><circle cx="4.98" cy="3.5" r="2"/><rect x="3.5" y="8" width="2.97" height="13"/><path d="M9 8h3v1.8h.05c.42-.8 1.46-1.8 3-1.8 3.2 0 3.8 2.1 3.8 4.9V21H16v-7.5c0-1.8-.03-4-2.5-4-2.5 0-2.9 1.9-2.9 3.9V21H9V8z"/></svg>
@@ -471,12 +478,22 @@
       return window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
 
-    html.classList.toggle('dark-mode', isDark());
+    var sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+    var moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+
+    function updateIcon(dark) {
+      toggle.innerHTML = dark ? moonIcon : sunIcon;
+    }
+
+    var dark = isDark();
+    html.classList.toggle('dark-mode', dark);
+    updateIcon(dark);
 
     toggle.addEventListener('click', function() {
       var next = !html.classList.contains('dark-mode');
       localStorage.setItem('theme', next ? 'dark' : 'light');
       html.classList.toggle('dark-mode', next);
+      updateIcon(next);
     });
   })();
 </script>

--- a/index.html
+++ b/index.html
@@ -72,6 +72,12 @@
       gap: 28px;
     }
 
+    .header-controls {
+      display: flex;
+      align-items: center;
+      gap: 28px;
+    }
+
     nav a {
       color: var(--muted);
       text-decoration: none;
@@ -152,8 +158,8 @@
         padding: 12px 0;
       }
 
-      nav .theme-toggle {
-        margin-top: 8px;
+      .header-controls {
+        gap: 12px;
       }
     }
 
@@ -174,27 +180,65 @@
     }
 
     html.dark-mode .hero-avatar {
-      border: 3px solid #FFFFFF;
+      border: 4px solid #FFFFFF;
+    }
+
+    html.dark-mode .hero-portrait-ring {
+      opacity: 0.35;
     }
 
     main {
       max-width: 640px;
       margin: 0 auto;
-      padding: 48px 24px 120px;
+      padding: 0 24px 120px;
+    }
+
+    .hero {
+      border-bottom: 1px solid var(--border);
+      padding: 48px 24px 40px;
+    }
+
+    .hero-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      gap: 28px;
+    }
+
+    .hero-portrait-wrap {
+      position: relative;
+      width: 112px;
+      height: 112px;
+      margin: 0 auto;
+      order: -1;
+    }
+
+    .hero-portrait-ring {
+      position: absolute;
+      inset: -14px;
+      border-radius: 50%;
+      background: var(--border);
+      opacity: 0.55;
+      z-index: 0;
     }
 
     .hero-avatar {
-      width: 64px;
-      height: 64px;
+      position: relative;
+      z-index: 1;
+      width: 100%;
+      height: 100%;
       border-radius: 50%;
       object-fit: cover;
       display: block;
-      margin: 0 0 20px;
     }
 
     .hero-name {
-      font-size: 40px;
+      font-size: clamp(2.25rem, 4vw + 1.4rem, 2.375rem);
       font-weight: 700;
+      line-height: 1.15;
+      letter-spacing: -0.01em;
       color: var(--ink);
       margin: 0;
     }
@@ -204,13 +248,57 @@
       font-weight: 400;
       color: var(--muted);
       line-height: 1.6;
-      margin: 20px 0 0;
+      max-width: 46ch;
+      margin: 16px 0 0;
     }
 
     .social-row {
       display: flex;
       gap: 12px;
-      margin-top: 24px;
+      margin-top: 28px;
+    }
+
+    @media (min-width: 860px) {
+      .hero {
+        padding: 72px 24px 64px;
+      }
+
+      .hero-inner {
+        display: grid;
+        grid-template-columns: 1fr 320px;
+        align-items: center;
+        gap: 64px;
+      }
+
+      .hero-portrait-wrap {
+        width: 300px;
+        height: 300px;
+        margin: 0;
+        order: 0;
+      }
+
+      .hero-name {
+        font-size: clamp(2.25rem, 2vw + 1.6rem, 2.5rem);
+      }
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      .hero-portrait-wrap,
+      .hero-name,
+      .hero-subtext,
+      .hero-content .social-row {
+        animation: hero-rise 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+      }
+
+      .hero-portrait-wrap { animation-delay: 0s; }
+      .hero-name { animation-delay: 0.08s; }
+      .hero-subtext { animation-delay: 0.16s; }
+      .hero-content .social-row { animation-delay: 0.24s; }
+    }
+
+    @keyframes hero-rise {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: translateY(0); }
     }
 
     .social-box {
@@ -226,8 +314,8 @@
     }
 
     .social-box:hover {
-      border-color: #3EC6B0;
-      color: #3EC6B0;
+      border-color: #EC4899;
+      color: #EC4899;
     }
 
     .social-box svg {
@@ -235,17 +323,8 @@
       height: 18px;
     }
 
-    section {
+    main section {
       margin-top: 56px;
-    }
-
-    .section-label {
-      font-size: 13px;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      color: var(--muted);
-      margin: 0 0 16px;
     }
 
     .impact-list {
@@ -297,6 +376,151 @@
       font-weight: 400;
       color: var(--muted);
       margin: 4px 0 0;
+    }
+
+    .impact-heading {
+      font-size: 20px;
+      font-weight: 700;
+      letter-spacing: -0.005em;
+      color: var(--ink);
+      margin: 0 0 16px;
+    }
+
+    .impact-grid {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .impact-card {
+      display: block;
+      padding: 20px;
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      text-decoration: none;
+      color: var(--ink);
+      transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1), border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .impact-card:hover {
+      transform: translateY(-2px);
+      border-color: var(--ink);
+      box-shadow: 0 10px 24px rgba(26, 26, 26, 0.08);
+    }
+
+    .impact-card-featured {
+      background: rgba(236, 72, 153, 0.05);
+      border-color: rgba(236, 72, 153, 0.25);
+    }
+
+    .impact-card-featured:hover {
+      border-color: #EC4899;
+      box-shadow: 0 10px 24px rgba(236, 72, 153, 0.12);
+    }
+
+    .impact-stat-row {
+      display: flex;
+      gap: 28px;
+      margin: 0 0 18px;
+    }
+
+    .impact-stat-number {
+      font-size: 28px;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+      color: var(--ink);
+      margin: 0;
+    }
+
+    .impact-stat-label {
+      font-size: 13px;
+      font-weight: 400;
+      color: var(--muted);
+      margin: 2px 0 0;
+    }
+
+    .impact-card-head {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .impact-card-title {
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--ink);
+      margin: 0;
+    }
+
+    .impact-card-arrow {
+      color: #EC4899;
+      font-size: 16px;
+      flex-shrink: 0;
+      transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    .impact-card:hover .impact-card-arrow {
+      transform: translateX(3px);
+    }
+
+    .impact-card-subtitle {
+      font-size: 14px;
+      font-weight: 400;
+      color: var(--muted);
+      margin: 4px 0 0;
+    }
+
+    .writing-list {
+      display: flex;
+      flex-direction: column;
+      gap: 28px;
+    }
+
+    .writing-item {
+      display: block;
+      text-decoration: none;
+      color: var(--ink);
+    }
+
+    .writing-item-head {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 16px;
+    }
+
+    .writing-item-title {
+      font-size: 18px;
+      font-weight: 600;
+      letter-spacing: -0.005em;
+      color: var(--ink);
+      margin: 0;
+      transition: color 0.2s ease;
+    }
+
+    .writing-item:hover .writing-item-title {
+      color: #EC4899;
+    }
+
+    .writing-item-arrow {
+      color: #EC4899;
+      font-size: 16px;
+      flex-shrink: 0;
+      transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    .writing-item:hover .writing-item-arrow {
+      transform: translateX(3px);
+    }
+
+    .writing-item-subtitle {
+      font-size: 14px;
+      font-weight: 400;
+      line-height: 1.55;
+      color: var(--muted);
+      max-width: 60ch;
+      margin: 8px 0 0;
     }
 
     .work-card {
@@ -387,32 +611,43 @@
       min-width: 0;
     }
 
-    .work-header {
+    .work-company {
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--ink);
+      margin: 0 0 8px;
+    }
+
+    .work-stints {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .work-stint {
       display: flex;
       align-items: baseline;
       justify-content: space-between;
       gap: 12px;
     }
 
-    .work-title {
-      font-size: 16px;
-      font-weight: 600;
-      color: var(--ink);
-      margin: 0;
-    }
-
-    .work-subtitle {
+    .work-role {
       font-size: 14px;
       font-weight: 400;
       color: var(--muted);
-      margin: 3px 0 0;
+      margin: 0;
     }
 
     .work-dates {
-      font-size: 14px;
+      font-size: 13px;
       color: var(--muted);
       white-space: nowrap;
       flex-shrink: 0;
+    }
+
+    .work-dates-current {
+      color: var(--ink);
+      font-weight: 600;
     }
 
   </style>
@@ -430,151 +665,172 @@
     <a href="index.html" class="brand-name">Austin Edmonson</a>
   </div>
 
-  <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-  </button>
-
-  <nav id="siteNav">
-    <a href="index.html">Home</a>
+  <div class="header-controls">
+    <nav id="siteNav">
     <a href="writing/index.html">Articles</a>
     <a href="about.html">About</a>
     <a href="projects/index.html">Projects</a>
     <a href="uses.html">Uses</a>
+    </nav>
+
     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
       </svg>
     </button>
-  </nav>
+
+    <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+  </div>
 </header>
 
-<main>
-  <img src="assets/austin-headshot.jpeg" alt="Austin Edmonson" class="hero-avatar" />
-  <h1 class="hero-name">I build internal platforms that make thousands of engineers faster.</h1>
-  <p class="hero-subtext">Senior Platform Engineer focused on developer experience, CI/CD, Kubernetes, and AI-assisted software delivery.</p>
-  <p class="hero-subtext">I design systems that remove friction from the software development lifecycle so engineering teams can ship software faster, safer, and with more confidence.</p>
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-portrait-wrap">
+      <div class="hero-portrait-ring" aria-hidden="true"></div>
+      <img src="assets/austin-headshot.jpeg" alt="Austin Edmonson" class="hero-avatar" />
+    </div>
+    <div class="hero-content">
+      <h1 class="hero-name">I build internal platforms that make thousands of engineers faster.</h1>
+      <p class="hero-subtext">Senior Platform Engineer focused on developer experience, CI/CD, Kubernetes, and AI-assisted software delivery.</p>
 
-  <div class="social-row">
-    <a href="https://linkedin.com/in/abedmonson" target="_blank" rel="noopener" class="social-box">
-      <svg viewBox="0 0 24 24" fill="currentColor"><circle cx="4.98" cy="3.5" r="2"/><rect x="3.5" y="8" width="2.97" height="13"/><path d="M9 8h3v1.8h.05c.42-.8 1.46-1.8 3-1.8 3.2 0 3.8 2.1 3.8 4.9V21H16v-7.5c0-1.8-.03-4-2.5-4-2.5 0-2.9 1.9-2.9 3.9V21H9V8z"/></svg>
-    </a>
-    <a href="https://github.com/ausbernard" target="_blank" rel="noopener" class="social-box">
-      <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5C5.73.5.5 5.73.5 12c0 5.1 3.29 9.4 7.86 10.93.57.1.78-.25.78-.55 0-.27-.01-1.16-.02-2.11-3.2.7-3.88-1.36-3.88-1.36-.52-1.33-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.02 1.75 2.68 1.25 3.34.95.1-.74.4-1.25.72-1.53-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.29 1.19-3.09-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.78 0c2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.76.12 3.05.74.8 1.18 1.83 1.18 3.09 0 4.43-2.69 5.41-5.25 5.69.41.36.78 1.07.78 2.15 0 1.55-.01 2.8-.01 3.18 0 .3.2.66.79.55A10.51 10.51 0 0 0 23.5 12c0-6.27-5.23-11.5-11.5-11.5Z"/></svg>
-    </a>
+      <div class="social-row">
+        <a href="https://linkedin.com/in/abedmonson" target="_blank" rel="noopener" class="social-box">
+          <svg viewBox="0 0 24 24" fill="currentColor"><circle cx="4.98" cy="3.5" r="2"/><rect x="3.5" y="8" width="2.97" height="13"/><path d="M9 8h3v1.8h.05c.42-.8 1.46-1.8 3-1.8 3.2 0 3.8 2.1 3.8 4.9V21H16v-7.5c0-1.8-.03-4-2.5-4-2.5 0-2.9 1.9-2.9 3.9V21H9V8z"/></svg>
+        </a>
+        <a href="https://github.com/ausbernard" target="_blank" rel="noopener" class="social-box">
+          <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5C5.73.5.5 5.73.5 12c0 5.1 3.29 9.4 7.86 10.93.57.1.78-.25.78-.55 0-.27-.01-1.16-.02-2.11-3.2.7-3.88-1.36-3.88-1.36-.52-1.33-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.02 1.75 2.68 1.25 3.34.95.1-.74.4-1.25.72-1.53-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.29 1.19-3.09-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.78 0c2.2-1.49 3.17-1.18 3.17-1.18.64 1.59.24 2.76.12 3.05.74.8 1.18 1.83 1.18 3.09 0 4.43-2.69 5.41-5.25 5.69.41.36.78 1.07.78 2.15 0 1.55-.01 2.8-.01 3.18 0 .3.2.66.79.55A10.51 10.51 0 0 0 23.5 12c0-6.27-5.23-11.5-11.5-11.5Z"/></svg>
+        </a>
+        <a href="mailto:austinbedmonson@gmail.com" class="social-box">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-10 5L2 7"/></svg>
+        </a>
+      </div>
+    </div>
   </div>
+</section>
 
+<main>
   <section>
-    <p class="section-label">Engineering Impact</p>
-    <div class="impact-list">
-      <a href="work/cicd-platform.html" class="impact-item">
-        <span class="impact-arrow">→</span>
-        <span>
-          <p class="impact-title">CI/CD Platform</p>
-          <p class="impact-subtitle">Standardized software delivery for 3,000+ engineers across 300,000+ repositories.</p>
-        </span>
+    <h2 class="impact-heading">Engineering impact</h2>
+    <div class="impact-grid">
+      <a href="work/cicd-platform.html" class="impact-card impact-card-featured">
+        <div class="impact-stat-row">
+          <div>
+            <p class="impact-stat-number">5K+</p>
+            <p class="impact-stat-label">engineers</p>
+          </div>
+          <div>
+            <p class="impact-stat-number">52K+</p>
+            <p class="impact-stat-label">repositories</p>
+          </div>
+        </div>
+        <div class="impact-card-head">
+          <p class="impact-card-title">CI/CD Platform</p>
+          <span class="impact-card-arrow" aria-hidden="true">→</span>
+        </div>
+        <p class="impact-card-subtitle">Standardized software delivery across the organization.</p>
       </a>
-      <a href="work/github-actions-platform.html" class="impact-item">
-        <span class="impact-arrow">→</span>
-        <span>
-          <p class="impact-title">GitHub Actions Runner Platform</p>
-          <p class="impact-subtitle">Elastic Kubernetes runners powering enterprise builds</p>
-        </span>
+      <a href="work/github-actions-platform.html" class="impact-card">
+        <div class="impact-card-head">
+          <p class="impact-card-title">GitHub Actions Runner Platform</p>
+          <span class="impact-card-arrow" aria-hidden="true">→</span>
+        </div>
+        <p class="impact-card-subtitle">Elastic Kubernetes runners powering enterprise builds.</p>
       </a>
-      <a href="work/enterprise-ai-adoption.html" class="impact-item">
-        <span class="impact-arrow">→</span>
-        <span>
-          <p class="impact-title">Enterprise AI Adoption</p>
-          <p class="impact-subtitle">Leading organization-wide AI integration into the SDLC</p>
-        </span>
+      <a href="work/enterprise-ai-adoption.html" class="impact-card">
+        <div class="impact-card-head">
+          <p class="impact-card-title">Enterprise AI Adoption</p>
+          <span class="impact-card-arrow" aria-hidden="true">→</span>
+        </div>
+        <p class="impact-card-subtitle">Leading organization-wide AI integration into the SDLC.</p>
       </a>
-      <a href="work/ai-developer-workflows.html" class="impact-item">
-        <span class="impact-arrow">→</span>
-        <span>
-          <p class="impact-title">AI Developer Workflows</p>
-          <p class="impact-subtitle">Claude reviews, agentic automation, developer tooling</p>
-        </span>
+      <a href="work/ai-developer-workflows.html" class="impact-card">
+        <div class="impact-card-head">
+          <p class="impact-card-title">AI Developer Workflows</p>
+          <span class="impact-card-arrow" aria-hidden="true">→</span>
+        </div>
+        <p class="impact-card-subtitle">Claude reviews, agentic automation, developer tooling.</p>
       </a>
     </div>
   </section>
 
   <section>
-    <p class="section-label">Writing</p>
-    <div class="impact-list">
-      <a href="writing/hexagonal-architecture-didnt-fit.html" class="impact-item">
-        <span class="impact-arrow">→</span>
-        <span>
-          <p class="impact-title">Why Hexagonal Architecture Didn't Fit My Enterprise Reality</p>
-          <p class="impact-subtitle">Hexagonal, Clean, DDD—the vocabulary assumes one team owns every layer. But when ten teams own ten layers, the pressure you're actually managing is different. And nobody's named it yet.</p>
-        </span>
+    <h2 class="impact-heading">Writing</h2>
+    <div class="writing-list">
+      <a href="writing/hexagonal-architecture-didnt-fit.html" class="writing-item">
+        <div class="writing-item-head">
+          <p class="writing-item-title">Why Hexagonal Architecture Didn't Fit My Enterprise Reality</p>
+          <span class="writing-item-arrow" aria-hidden="true">→</span>
+        </div>
+        <p class="writing-item-subtitle">Hexagonal, Clean, DDD: the vocabulary assumes one team owns every layer. When ten teams own ten layers, the pressure is different, and nobody's named it yet.</p>
       </a>
-      <a href="writing/partida-technical-breakdown.html" class="impact-item">
-        <span class="impact-arrow">→</span>
-        <span>
-          <p class="impact-title">Building Partida: A Technical Breakdown</p>
-          <p class="impact-subtitle">Real bugs, real code, real numbers — the split Base import, the Alembic surprise, the enum-as-primary-key that broke at scale.</p>
-        </span>
+      <a href="writing/partida-technical-breakdown.html" class="writing-item">
+        <div class="writing-item-head">
+          <p class="writing-item-title">Building Partida: A Technical Breakdown</p>
+          <span class="writing-item-arrow" aria-hidden="true">→</span>
+        </div>
+        <p class="writing-item-subtitle">Real bugs, real code, real numbers: the split Base import, the Alembic surprise, the enum-as-primary-key that broke at scale.</p>
       </a>
-      <a href="writing/overengineering-operational-exhaustion.html" class="impact-item">
-        <span class="impact-arrow">→</span>
-        <span>
-          <p class="impact-title">We Were Overengineering Ourselves Into Operational Exhaustion</p>
-          <p class="impact-subtitle">What happens when a small team inherits infrastructure patterns built for a platform org three times its size.</p>
-        </span>
+      <a href="writing/overengineering-operational-exhaustion.html" class="writing-item">
+        <div class="writing-item-head">
+          <p class="writing-item-title">We Were Overengineering Ourselves Into Operational Exhaustion</p>
+          <span class="writing-item-arrow" aria-hidden="true">→</span>
+        </div>
+        <p class="writing-item-subtitle">What happens when a small team inherits infrastructure patterns built for a platform org three times its size.</p>
       </a>
     </div>
   </section>
 
   <section>
     <div class="work-card">
-    <p class="section-label">Work</p>
+    <h2 class="impact-heading">Work</h2>
     <div class="work-list">
       <div class="work-item">
         <div class="work-logo work-logo-fill">
           <img src="assets/home-depot-logo.png" alt="The Home Depot" />
         </div>
         <div class="work-body">
-            <div class="work-header">
-              <p class="work-title">The Home Depot</p>
-              <span class="work-dates">2025 — Present</span>
+          <p class="work-company">The Home Depot</p>
+          <div class="work-stints">
+            <div class="work-stint">
+              <p class="work-role">Senior Software Engineer</p>
+              <span class="work-dates work-dates-current">2025 - Present</span>
             </div>
-            <p class="work-subtitle">Senior Software Engineer</p>
+            <div class="work-stint">
+              <p class="work-role">Software Engineer I &amp; II</p>
+              <span class="work-dates">2022 - 2025</span>
+            </div>
           </div>
-      </div>
-      <div class="work-item">
-        <div class="work-logo work-logo-fill">
-          <img src="assets/home-depot-logo.png" alt="The Home Depot" />
         </div>
-        <div class="work-body">
-            <div class="work-header">
-              <p class="work-title">The Home Depot</p>
-              <span class="work-dates">2022 — 2025</span>
-            </div>
-            <p class="work-subtitle">Software Engineer I &amp; II</p>
-          </div>
       </div>
       <div class="work-item">
         <div class="work-logo work-logo-fill">
           <img src="assets/acoustic-ai-logo.jpeg" alt="Acoustic AI" />
         </div>
         <div class="work-body">
-            <div class="work-header">
-              <p class="work-title">Acoustic AI</p>
+          <p class="work-company">Acoustic AI</p>
+          <div class="work-stints">
+            <div class="work-stint">
+              <p class="work-role">Systems Engineer</p>
               <span class="work-dates">2020</span>
             </div>
-            <p class="work-subtitle">Systems Engineer</p>
           </div>
+        </div>
       </div>
       <div class="work-item">
         <div class="work-logo work-logo-img">
           <img src="assets/shadow-soft-logo.png" alt="Shadow Soft" />
         </div>
         <div class="work-body">
-            <div class="work-header">
-              <p class="work-title">Shadow Soft</p>
-              <span class="work-dates">2019 — 2020</span>
+          <p class="work-company">Shadow Soft</p>
+          <div class="work-stints">
+            <div class="work-stint">
+              <p class="work-role">DevOps Intern</p>
+              <span class="work-dates">2019 - 2020</span>
             </div>
-            <p class="work-subtitle">DevOps Intern</p>
           </div>
+        </div>
       </div>
     </div>
     <a href="assets/Austin-Edmonson-CV-EU.pdf" class="work-cv-button" target="_blank" rel="noopener">
@@ -604,12 +860,22 @@
       return window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
 
-    html.classList.toggle('dark-mode', isDark());
+    var sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+    var moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+
+    function updateIcon(dark) {
+      toggle.innerHTML = dark ? moonIcon : sunIcon;
+    }
+
+    var dark = isDark();
+    html.classList.toggle('dark-mode', dark);
+    updateIcon(dark);
 
     toggle.addEventListener('click', function() {
       var next = !html.classList.contains('dark-mode');
       localStorage.setItem('theme', next ? 'dark' : 'light');
       html.classList.toggle('dark-mode', next);
+      updateIcon(next);
     });
   })();
 </script>

--- a/projects/index.html
+++ b/projects/index.html
@@ -72,6 +72,12 @@
       gap: 28px;
     }
 
+    .header-controls {
+      display: flex;
+      align-items: center;
+      gap: 28px;
+    }
+
     nav a {
       color: var(--muted);
       text-decoration: none;
@@ -79,9 +85,13 @@
       font-weight: 200;
     }
 
-    nav a:hover,
+    nav a:hover {
+      color: var(--ink);
+    }
+
     nav a.active {
       color: var(--ink);
+      font-weight: 600;
     }
 
     .theme-toggle {
@@ -153,8 +163,8 @@
         padding: 12px 0;
       }
 
-      nav .theme-toggle {
-        margin-top: 8px;
+      .header-controls {
+        gap: 12px;
       }
     }
 
@@ -199,28 +209,28 @@
       margin-top: 48px;
     }
 
-    .section-label {
-      font-size: 13px;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      color: var(--muted);
+    .projects-heading {
+      font-size: 20px;
+      font-weight: 700;
+      letter-spacing: -0.005em;
+      color: var(--ink);
       margin: 0 0 16px;
     }
 
     .oss-list {
       display: flex;
       flex-direction: column;
+      gap: 6px;
     }
 
     .oss-row {
+      position: relative;
       display: flex;
       align-items: flex-start;
       gap: 16px;
-      padding: 24px 16px;
+      padding: 24px 40px 24px 16px;
       margin: 0 -16px;
       border-radius: 10px;
-      border-bottom: 1px solid var(--border);
       text-decoration: none;
       color: inherit;
       transition: background-color 0.2s ease;
@@ -230,8 +240,17 @@
       background: rgba(26, 26, 26, 0.05);
     }
 
-    .oss-row:last-child {
-      border-bottom: none;
+    .oss-external {
+      position: absolute;
+      top: 24px;
+      right: 16px;
+      color: var(--muted);
+      font-size: 14px;
+      transition: color 0.2s ease;
+    }
+
+    .oss-row:hover .oss-external {
+      color: #EC4899;
     }
 
     .oss-repo-img {
@@ -341,22 +360,24 @@
     <a href="../index.html" class="brand-name">Austin Edmonson</a>
   </div>
 
-  <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-  </button>
-
-  <nav id="siteNav">
-    <a href="../index.html">Home</a>
+  <div class="header-controls">
+    <nav id="siteNav">
     <a href="../writing/index.html">Articles</a>
     <a href="../about.html">About</a>
     <a href="index.html" class="active">Projects</a>
     <a href="../uses.html">Uses</a>
+    </nav>
+
     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
       </svg>
     </button>
-  </nav>
+
+    <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+  </div>
 </header>
 
 <main>
@@ -364,40 +385,43 @@
   <p class="page-subtext">Things I've built, plus open source contributions along the way.</p>
 
   <section>
-    <p class="section-label">Repos</p>
+    <h2 class="projects-heading">Repos</h2>
     <div class="oss-list">
       <a href="https://github.com/ausbernard/Vigia" target="_blank" rel="noopener" class="oss-row">
+        <span class="oss-external" aria-hidden="true">↗</span>
         <img src="../assets/vigia-cover.jpg" alt="Vigia" class="oss-repo-img" />
         <div class="oss-body">
           <p class="oss-title">Vigia</p>
-          <p class="oss-desc">A read-only service that proxies the Railway API, reshapes deployment data, and surfaces project health across a workspace in a clean dashboard — FastAPI backend, React + Vite frontend.</p>
+          <p class="oss-desc">A read-only service that proxies the Railway API, reshapes deployment data, and surfaces project health across a workspace in a clean dashboard. FastAPI backend, React + Vite frontend.</p>
           <div class="oss-meta">
             <span class="oss-repo-name">ausbernard/Vigia</span>
-            <span class="oss-status">FastAPI · React ↗</span>
+            <span class="oss-status">FastAPI · React</span>
           </div>
         </div>
       </a>
 
       <a href="https://github.com/ausbernard/python-ci-pavedroad" target="_blank" rel="noopener" class="oss-row">
+        <span class="oss-external" aria-hidden="true">↗</span>
         <img src="../assets/python-ci-pavedroad-cover.jpg" alt="python-ci-pavedroad" class="oss-repo-img" />
         <div class="oss-body">
           <p class="oss-title">python-ci-pavedroad</p>
-          <p class="oss-desc">A reusable, production-ready CI/CD pipeline template for Python projects — GitHub Actions, Docker, pytest, and ruff wired up so new services start with testing and deployment already solved.</p>
+          <p class="oss-desc">A reusable, production-ready CI/CD pipeline template for Python projects: GitHub Actions, Docker, pytest, and ruff wired up so new services start with testing and deployment already solved.</p>
           <div class="oss-meta">
             <span class="oss-repo-name">ausbernard/python-ci-pavedroad</span>
-            <span class="oss-status">Python · Docker ↗</span>
+            <span class="oss-status">Python · Docker</span>
           </div>
         </div>
       </a>
 
       <a href="https://github.com/ausbernard/Cairn" target="_blank" rel="noopener" class="oss-row">
+        <span class="oss-external" aria-hidden="true">↗</span>
         <img src="../assets/cairn-cover.jpg" alt="Cairn" class="oss-repo-img" />
         <div class="oss-body">
           <p class="oss-title">Cairn</p>
-          <p class="oss-desc">A Rust CLI for people with no free time — capture ideas, use Claude to break them into 45-minute sessions with clear done-when criteria, and get learning tasks scheduled automatically when you're stuck instead of grinding on a blocker.</p>
+          <p class="oss-desc">A Rust CLI for people with no free time. Capture ideas, use Claude to break them into 45-minute sessions with clear done-when criteria, and get learning tasks scheduled automatically when you're stuck instead of grinding on a blocker.</p>
           <div class="oss-meta">
             <span class="oss-repo-name">ausbernard/Cairn</span>
-            <span class="oss-status">Rust · SQLite ↗</span>
+            <span class="oss-status">Rust · SQLite</span>
           </div>
         </div>
       </a>
@@ -405,40 +429,43 @@
   </section>
 
   <section>
-    <p class="section-label">Open Source Contributions</p>
+    <h2 class="projects-heading">Open Source Contributions</h2>
     <div class="oss-list">
       <a href="https://github.com/spotify/confidence-sdk-python/issues/114" target="_blank" rel="noopener" class="oss-row">
+        <span class="oss-external" aria-hidden="true">↗</span>
       <img src="https://github.com/spotify.png?size=80" alt="spotify" class="oss-repo-img" />
       <div class="oss-body">
         <p class="oss-title">Found shared mutable class-level context causing instance data leakage</p>
-        <p class="oss-desc">All <code>Confidence</code> instances shared the same class-level <code>context</code> dict — setting context on one silently contaminated all others. Identified the root cause, proposed moving initialization to <code>__init__</code>, and flagged a secondary risk with a shared <code>httpx.AsyncClient</code>.</p>
+        <p class="oss-desc">All <code>Confidence</code> instances shared the same class-level <code>context</code> dict: setting context on one silently contaminated all others. Identified the root cause, proposed moving initialization to <code>__init__</code>, and flagged a secondary risk with a shared <code>httpx.AsyncClient</code>.</p>
         <div class="oss-meta">
           <span class="oss-repo-name">spotify/confidence-sdk-python</span>
-          <span class="oss-status">Closed ↗</span>
+          <span class="oss-status">Closed</span>
         </div>
       </div>
     </a>
 
     <a href="https://github.com/gocardless/gocardless-pro-python/issues/129" target="_blank" rel="noopener" class="oss-row">
+        <span class="oss-external" aria-hidden="true">↗</span>
       <img src="https://github.com/gocardless.png?size=80" alt="gocardless" class="oss-repo-img" />
       <div class="oss-body">
         <p class="oss-title">Fixed rate_limit returning a dict instead of a RateLimit object</p>
         <p class="oss-desc">The public <code>Client.rate_limit</code> property broke documented attribute access (<code>.limit</code>, <code>.remaining</code>, <code>.reset</code>). Identified the gap between the internal API layer and the public interface, wrote a failing test, and submitted the fix.</p>
         <div class="oss-meta">
           <span class="oss-repo-name">gocardless/gocardless-pro-python</span>
-          <span class="oss-status">Closed ↗</span>
+          <span class="oss-status">Closed</span>
         </div>
       </div>
     </a>
 
     <a href="https://github.com/gocardless/gocardless-pro-python/issues/130" target="_blank" rel="noopener" class="oss-row">
+        <span class="oss-external" aria-hidden="true">↗</span>
       <img src="https://github.com/gocardless.png?size=80" alt="gocardless" class="oss-repo-img" />
       <div class="oss-body">
         <p class="oss-title">Added direct unit tests for the Paginator class</p>
         <p class="oss-desc">The <code>Paginator</code> class powers every <code>.all()</code> call in the library but had zero direct coverage. Added 7 isolated unit tests with <code>unittest.mock</code> covering multi-page traversal, cursor logic, parameter passing, empty responses, and mutation safety.</p>
         <div class="oss-meta">
           <span class="oss-repo-name">gocardless/gocardless-pro-python</span>
-          <span class="oss-status">Closed ↗</span>
+          <span class="oss-status">Closed</span>
         </div>
       </div>
     </a>
@@ -476,12 +503,22 @@
       return window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
 
-    html.classList.toggle('dark-mode', isDark());
+    var sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+    var moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+
+    function updateIcon(dark) {
+      toggle.innerHTML = dark ? moonIcon : sunIcon;
+    }
+
+    var dark = isDark();
+    html.classList.toggle('dark-mode', dark);
+    updateIcon(dark);
 
     toggle.addEventListener('click', function() {
       var next = !html.classList.contains('dark-mode');
       localStorage.setItem('theme', next ? 'dark' : 'light');
       html.classList.toggle('dark-mode', next);
+      updateIcon(next);
     });
   })();
 </script>

--- a/uses.html
+++ b/uses.html
@@ -72,6 +72,12 @@
       gap: 28px;
     }
 
+    .header-controls {
+      display: flex;
+      align-items: center;
+      gap: 28px;
+    }
+
     nav a {
       color: var(--muted);
       text-decoration: none;
@@ -79,9 +85,13 @@
       font-weight: 200;
     }
 
-    nav a:hover,
+    nav a:hover {
+      color: var(--ink);
+    }
+
     nav a.active {
       color: var(--ink);
+      font-weight: 600;
     }
 
     .theme-toggle {
@@ -153,8 +163,8 @@
         padding: 12px 0;
       }
 
-      nav .theme-toggle {
-        margin-top: 8px;
+      .header-controls {
+        gap: 12px;
       }
     }
 
@@ -199,12 +209,11 @@
       margin-top: 56px;
     }
 
-    .section-label {
-      font-size: 13px;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      color: var(--muted);
+    .uses-heading {
+      font-size: 20px;
+      font-weight: 700;
+      letter-spacing: -0.005em;
+      color: var(--ink);
       margin: 0 0 16px;
     }
 
@@ -243,22 +252,24 @@
     <a href="index.html" class="brand-name">Austin Edmonson</a>
   </div>
 
-  <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-  </button>
-
-  <nav id="siteNav">
-    <a href="index.html">Home</a>
+  <div class="header-controls">
+    <nav id="siteNav">
     <a href="writing/index.html">Articles</a>
     <a href="about.html">About</a>
     <a href="projects/index.html">Projects</a>
     <a href="uses.html" class="active">Uses</a>
+    </nav>
+
     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
       </svg>
     </button>
-  </nav>
+
+    <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+  </div>
 </header>
 
 <main>
@@ -266,7 +277,7 @@
   <p class="page-subtext">I prefer fewer, better tools over a sprawling stack. Every item on this list earned its spot by surviving real work. I update my technology when they are outgrown, not when something shiny comes up.</p>
 
   <section>
-    <p class="section-label">Workstation</p>
+    <h2 class="uses-heading">Workstation</h2>
     <div class="uses-list">
       <div>
         <p class="uses-item-title">15" MacBook Pro (2019)</p>
@@ -288,7 +299,7 @@
   </section>
 
   <section>
-    <p class="section-label">Editor and IDE</p>
+    <h2 class="uses-heading">Editor and IDE</h2>
     <div class="uses-list">
       <div>
         <p class="uses-item-title">Cursor</p>
@@ -302,7 +313,7 @@
   </section>
 
   <section>
-    <p class="section-label">AI in the Loop</p>
+    <h2 class="uses-heading">AI in the Loop</h2>
     <div class="uses-list">
       <div>
         <p class="uses-item-title">Claude and Claude Code</p>
@@ -310,13 +321,13 @@
       </div>
       <div>
         <p class="uses-item-title">Deepseek</p>
-        <p class="uses-item-desc">Hard-nosed techincal tutor.</p>
+        <p class="uses-item-desc">Hard-nosed technical tutor.</p>
       </div>
     </div>
   </section>
 
   <section>
-    <p class="section-label">Thinking and Writing</p>
+    <h2 class="uses-heading">Thinking and Writing</h2>
     <div class="uses-list">
       <div>
         <p class="uses-item-title">Obsidian</p>
@@ -330,7 +341,7 @@
   </section>
 
   <section>
-    <p class="section-label">Staying Organized</p>
+    <h2 class="uses-heading">Staying Organized</h2>
     <div class="uses-list">
       <div>
         <p class="uses-item-title">Notion</p>
@@ -363,12 +374,22 @@
       return window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
 
-    html.classList.toggle('dark-mode', isDark());
+    var sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+    var moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+
+    function updateIcon(dark) {
+      toggle.innerHTML = dark ? moonIcon : sunIcon;
+    }
+
+    var dark = isDark();
+    html.classList.toggle('dark-mode', dark);
+    updateIcon(dark);
 
     toggle.addEventListener('click', function() {
       var next = !html.classList.contains('dark-mode');
       localStorage.setItem('theme', next ? 'dark' : 'light');
       html.classList.toggle('dark-mode', next);
+      updateIcon(next);
     });
   })();
 </script>

--- a/work/ai-developer-workflows.html
+++ b/work/ai-developer-workflows.html
@@ -71,6 +71,12 @@
       gap: 28px;
     }
 
+    .header-controls {
+      display: flex;
+      align-items: center;
+      gap: 28px;
+    }
+
     nav a {
       color: var(--muted);
       text-decoration: none;
@@ -151,8 +157,8 @@
         padding: 12px 0;
       }
 
-      nav .theme-toggle {
-        margin-top: 8px;
+      .header-controls {
+        gap: 12px;
       }
     }
 
@@ -194,7 +200,7 @@
 
     .back-link:hover {
       border-color: var(--ink);
-      color: #3EC6B0;
+      color: #EC4899;
     }
 
     .case-title {
@@ -245,7 +251,7 @@
 
     .case-list li::before {
       content: "•";
-      color: #3EC6B0;
+      color: #EC4899;
       flex-shrink: 0;
     }
 
@@ -270,22 +276,24 @@
     <a href="../index.html" class="brand-name">Austin Edmonson</a>
   </div>
 
-  <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-  </button>
-
-  <nav id="siteNav">
-    <a href="../index.html">Home</a>
+  <div class="header-controls">
+    <nav id="siteNav">
     <a href="../writing/index.html">Articles</a>
     <a href="../about.html">About</a>
     <a href="../projects/index.html">Projects</a>
     <a href="../uses.html">Uses</a>
+    </nav>
+
     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
       </svg>
     </button>
-  </nav>
+
+    <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+  </div>
 </header>
 
 <main>
@@ -342,12 +350,22 @@
       return window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
 
-    html.classList.toggle('dark-mode', isDark());
+    var sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+    var moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+
+    function updateIcon(dark) {
+      toggle.innerHTML = dark ? moonIcon : sunIcon;
+    }
+
+    var dark = isDark();
+    html.classList.toggle('dark-mode', dark);
+    updateIcon(dark);
 
     toggle.addEventListener('click', function() {
       var next = !html.classList.contains('dark-mode');
       localStorage.setItem('theme', next ? 'dark' : 'light');
       html.classList.toggle('dark-mode', next);
+      updateIcon(next);
     });
   })();
 </script>

--- a/work/cicd-platform.html
+++ b/work/cicd-platform.html
@@ -71,6 +71,12 @@
       gap: 28px;
     }
 
+    .header-controls {
+      display: flex;
+      align-items: center;
+      gap: 28px;
+    }
+
     nav a {
       color: var(--muted);
       text-decoration: none;
@@ -151,8 +157,8 @@
         padding: 12px 0;
       }
 
-      nav .theme-toggle {
-        margin-top: 8px;
+      .header-controls {
+        gap: 12px;
       }
     }
 
@@ -194,7 +200,7 @@
 
     .back-link:hover {
       border-color: var(--ink);
-      color: #3EC6B0;
+      color: #EC4899;
     }
 
     .case-title {
@@ -261,7 +267,7 @@
 
     .case-list li::before {
       content: "•";
-      color: #3EC6B0;
+      color: #EC4899;
       flex-shrink: 0;
     }
 
@@ -327,22 +333,24 @@
     <a href="../index.html" class="brand-name">Austin Edmonson</a>
   </div>
 
-  <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-  </button>
-
-  <nav id="siteNav">
-    <a href="../index.html">Home</a>
+  <div class="header-controls">
+    <nav id="siteNav">
     <a href="../writing/index.html">Articles</a>
     <a href="../about.html">About</a>
     <a href="../projects/index.html">Projects</a>
     <a href="../uses.html">Uses</a>
+    </nav>
+
     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
       </svg>
     </button>
-  </nav>
+
+    <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+  </div>
 </header>
 
 <main>
@@ -353,7 +361,7 @@
 
   <section>
     <p class="section-label">Problem</p>
-    <p class="impact-stat" style="margin-bottom: 16px;">3,000+ engineers. 300,000+ repositories. No standard way to ship code.</p>
+    <p class="impact-stat" style="margin-bottom: 16px;">5,000+ engineers. 52,000+ repositories. No standard way to ship code.</p>
     <p class="case-text">Every team built pipelines differently — TeamCity, Concourse, Jenkins, GitHub Actions.</p>
     <p class="case-text">Maintainability and costs were fragmented across different teams.</p>
     <p class="case-text">Developer onboarding to these tools was inconsistent.</p>
@@ -446,8 +454,8 @@
 
   <section>
     <p class="section-label">Impact</p>
-    <p class="impact-stat">3,000+ engineers</p>
-    <p class="impact-stat">300,000+ repositories</p>
+    <p class="impact-stat">5,000+ engineers</p>
+    <p class="impact-stat">52,000+ repositories</p>
   </section>
 
   <section>
@@ -487,12 +495,22 @@
       return window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
 
-    html.classList.toggle('dark-mode', isDark());
+    var sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+    var moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+
+    function updateIcon(dark) {
+      toggle.innerHTML = dark ? moonIcon : sunIcon;
+    }
+
+    var dark = isDark();
+    html.classList.toggle('dark-mode', dark);
+    updateIcon(dark);
 
     toggle.addEventListener('click', function() {
       var next = !html.classList.contains('dark-mode');
       localStorage.setItem('theme', next ? 'dark' : 'light');
       html.classList.toggle('dark-mode', next);
+      updateIcon(next);
     });
   })();
 </script>

--- a/work/enterprise-ai-adoption.html
+++ b/work/enterprise-ai-adoption.html
@@ -71,6 +71,12 @@
       gap: 28px;
     }
 
+    .header-controls {
+      display: flex;
+      align-items: center;
+      gap: 28px;
+    }
+
     nav a {
       color: var(--muted);
       text-decoration: none;
@@ -151,8 +157,8 @@
         padding: 12px 0;
       }
 
-      nav .theme-toggle {
-        margin-top: 8px;
+      .header-controls {
+        gap: 12px;
       }
     }
 
@@ -194,7 +200,7 @@
 
     .back-link:hover {
       border-color: var(--ink);
-      color: #3EC6B0;
+      color: #EC4899;
     }
 
     .case-title {
@@ -245,7 +251,7 @@
 
     .case-list li::before {
       content: "•";
-      color: #3EC6B0;
+      color: #EC4899;
       flex-shrink: 0;
     }
 
@@ -270,22 +276,24 @@
     <a href="../index.html" class="brand-name">Austin Edmonson</a>
   </div>
 
-  <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-  </button>
-
-  <nav id="siteNav">
-    <a href="../index.html">Home</a>
+  <div class="header-controls">
+    <nav id="siteNav">
     <a href="../writing/index.html">Articles</a>
     <a href="../about.html">About</a>
     <a href="../projects/index.html">Projects</a>
     <a href="../uses.html">Uses</a>
+    </nav>
+
     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
       </svg>
     </button>
-  </nav>
+
+    <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+  </div>
 </header>
 
 <main>
@@ -342,12 +350,22 @@
       return window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
 
-    html.classList.toggle('dark-mode', isDark());
+    var sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+    var moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+
+    function updateIcon(dark) {
+      toggle.innerHTML = dark ? moonIcon : sunIcon;
+    }
+
+    var dark = isDark();
+    html.classList.toggle('dark-mode', dark);
+    updateIcon(dark);
 
     toggle.addEventListener('click', function() {
       var next = !html.classList.contains('dark-mode');
       localStorage.setItem('theme', next ? 'dark' : 'light');
       html.classList.toggle('dark-mode', next);
+      updateIcon(next);
     });
   })();
 </script>

--- a/work/github-actions-platform.html
+++ b/work/github-actions-platform.html
@@ -71,6 +71,12 @@
       gap: 28px;
     }
 
+    .header-controls {
+      display: flex;
+      align-items: center;
+      gap: 28px;
+    }
+
     nav a {
       color: var(--muted);
       text-decoration: none;
@@ -151,8 +157,8 @@
         padding: 12px 0;
       }
 
-      nav .theme-toggle {
-        margin-top: 8px;
+      .header-controls {
+        gap: 12px;
       }
     }
 
@@ -194,7 +200,7 @@
 
     .back-link:hover {
       border-color: var(--ink);
-      color: #3EC6B0;
+      color: #EC4899;
     }
 
     .case-title {
@@ -261,7 +267,7 @@
 
     .case-list li::before {
       content: "•";
-      color: #3EC6B0;
+      color: #EC4899;
       flex-shrink: 0;
     }
 
@@ -280,8 +286,8 @@
     }
 
     .case-link:hover {
-      color: #3EC6B0;
-      text-decoration-color: #3EC6B0;
+      color: #EC4899;
+      text-decoration-color: #EC4899;
     }
 
   </style>
@@ -299,22 +305,24 @@
     <a href="../index.html" class="brand-name">Austin Edmonson</a>
   </div>
 
-  <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-  </button>
-
-  <nav id="siteNav">
-    <a href="../index.html">Home</a>
+  <div class="header-controls">
+    <nav id="siteNav">
     <a href="../writing/index.html">Articles</a>
     <a href="../about.html">About</a>
     <a href="../projects/index.html">Projects</a>
     <a href="../uses.html">Uses</a>
+    </nav>
+
     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
       </svg>
     </button>
-  </nav>
+
+    <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+  </div>
 </header>
 
 <main>
@@ -409,12 +417,22 @@
       return window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
 
-    html.classList.toggle('dark-mode', isDark());
+    var sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+    var moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+
+    function updateIcon(dark) {
+      toggle.innerHTML = dark ? moonIcon : sunIcon;
+    }
+
+    var dark = isDark();
+    html.classList.toggle('dark-mode', dark);
+    updateIcon(dark);
 
     toggle.addEventListener('click', function() {
       var next = !html.classList.contains('dark-mode');
       localStorage.setItem('theme', next ? 'dark' : 'light');
       html.classList.toggle('dark-mode', next);
+      updateIcon(next);
     });
   })();
 </script>

--- a/writing/cicd-same-image.html
+++ b/writing/cicd-same-image.html
@@ -72,6 +72,12 @@
       gap: 28px;
     }
 
+    .header-controls {
+      display: flex;
+      align-items: center;
+      gap: 28px;
+    }
+
     nav a {
       color: var(--muted);
       text-decoration: none;
@@ -79,9 +85,13 @@
       font-weight: 200;
     }
 
-    nav a:hover,
+    nav a:hover {
+      color: var(--ink);
+    }
+
     nav a.active {
       color: var(--ink);
+      font-weight: 600;
     }
 
     .theme-toggle {
@@ -153,8 +163,8 @@
         padding: 12px 0;
       }
 
-      nav .theme-toggle {
-        margin-top: 8px;
+      .header-controls {
+        gap: 12px;
       }
     }
 
@@ -195,8 +205,8 @@
     }
 
     .post-back:hover {
-      color: var(--ink);
-      border-color: var(--ink);
+      color: #EC4899;
+      border-color: #EC4899;
     }
 
     .post-title {
@@ -218,8 +228,25 @@
       width: 100%;
       max-height: 320px;
       object-fit: cover;
-      border-radius: 12px;
+      border-radius: 16px;
       margin-top: 32px;
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      .post-title,
+      .post-date,
+      .post-hero {
+        animation: post-rise 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+      }
+
+      .post-title { animation-delay: 0s; }
+      .post-date { animation-delay: 0.08s; }
+      .post-hero { animation-delay: 0.16s; }
+    }
+
+    @keyframes post-rise {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: translateY(0); }
     }
 
     .post-body {
@@ -338,28 +365,30 @@
     <a href="../index.html" class="brand-name">Austin Edmonson</a>
   </div>
 
-  <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-  </button>
-
-  <nav id="siteNav">
-    <a href="../index.html">Home</a>
+  <div class="header-controls">
+    <nav id="siteNav">
     <a href="index.html" class="active">Articles</a>
     <a href="../about.html">About</a>
     <a href="../projects/index.html">Projects</a>
     <a href="../uses.html">Uses</a>
+    </nav>
+
     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
       </svg>
     </button>
-  </nav>
+
+    <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+  </div>
 </header>
 
 <main>
-  <a href="index.html" class="post-back">←</a>
+  <a href="index.html" class="post-back" aria-label="Back to articles">←</a>
   <h1 class="post-title">We Stopped Trusting Deployments Until We Fixed This</h1>
-  <p class="post-date">May 2026</p>
+  <p class="post-date">May 2026 · 5 min read</p>
 
   <img src="../assets/cicd-same-image-hero.jpg" alt="Painting of a city skyline at dusk with a translucent square overlay and a building glowing orange" class="post-hero" />
 
@@ -655,12 +684,22 @@ production → live environment</code></pre>
       return window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
 
-    html.classList.toggle('dark-mode', isDark());
+    var sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+    var moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+
+    function updateIcon(dark) {
+      toggle.innerHTML = dark ? moonIcon : sunIcon;
+    }
+
+    var dark = isDark();
+    html.classList.toggle('dark-mode', dark);
+    updateIcon(dark);
 
     toggle.addEventListener('click', function() {
       var next = !html.classList.contains('dark-mode');
       localStorage.setItem('theme', next ? 'dark' : 'light');
       html.classList.toggle('dark-mode', next);
+      updateIcon(next);
     });
   })();
 </script>

--- a/writing/hexagonal-architecture-didnt-fit.html
+++ b/writing/hexagonal-architecture-didnt-fit.html
@@ -72,6 +72,12 @@
       gap: 28px;
     }
 
+    .header-controls {
+      display: flex;
+      align-items: center;
+      gap: 28px;
+    }
+
     nav a {
       color: var(--muted);
       text-decoration: none;
@@ -79,9 +85,13 @@
       font-weight: 200;
     }
 
-    nav a:hover,
+    nav a:hover {
+      color: var(--ink);
+    }
+
     nav a.active {
       color: var(--ink);
+      font-weight: 600;
     }
 
     .theme-toggle {
@@ -153,8 +163,8 @@
         padding: 12px 0;
       }
 
-      nav .theme-toggle {
-        margin-top: 8px;
+      .header-controls {
+        gap: 12px;
       }
     }
 
@@ -195,8 +205,8 @@
     }
 
     .post-back:hover {
-      color: var(--ink);
-      border-color: var(--ink);
+      color: #EC4899;
+      border-color: #EC4899;
     }
 
     .post-title {
@@ -218,8 +228,25 @@
       width: 100%;
       max-height: 320px;
       object-fit: cover;
-      border-radius: 12px;
+      border-radius: 16px;
       margin-top: 32px;
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      .post-title,
+      .post-date,
+      .post-hero {
+        animation: post-rise 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+      }
+
+      .post-title { animation-delay: 0s; }
+      .post-date { animation-delay: 0.08s; }
+      .post-hero { animation-delay: 0.16s; }
+    }
+
+    @keyframes post-rise {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: translateY(0); }
     }
 
     .post-body {
@@ -338,28 +365,30 @@
     <a href="../index.html" class="brand-name">Austin Edmonson</a>
   </div>
 
-  <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-  </button>
-
-  <nav id="siteNav">
-    <a href="../index.html">Home</a>
+  <div class="header-controls">
+    <nav id="siteNav">
     <a href="index.html" class="active">Articles</a>
     <a href="../about.html">About</a>
     <a href="../projects/index.html">Projects</a>
     <a href="../uses.html">Uses</a>
+    </nav>
+
     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
       </svg>
     </button>
-  </nav>
+
+    <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+  </div>
 </header>
 
 <main>
-  <a href="index.html" class="post-back">←</a>
+  <a href="index.html" class="post-back" aria-label="Back to articles">←</a>
   <h1 class="post-title">Why Hexagonal Architecture Didn't Fit My Enterprise Reality</h1>
-  <p class="post-date">July 2026</p>
+  <p class="post-date">July 2026 · 5 min read</p>
 
   <img src="../assets/buy-vs-build-hero.jpg" alt="Grid of blurred, ghostlike figures walking past a translucent screen, each marked with a small dot, evoking repeated observation and pattern" class="post-hero" />
 
@@ -431,12 +460,22 @@
       return window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
 
-    html.classList.toggle('dark-mode', isDark());
+    var sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+    var moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+
+    function updateIcon(dark) {
+      toggle.innerHTML = dark ? moonIcon : sunIcon;
+    }
+
+    var dark = isDark();
+    html.classList.toggle('dark-mode', dark);
+    updateIcon(dark);
 
     toggle.addEventListener('click', function() {
       var next = !html.classList.contains('dark-mode');
       localStorage.setItem('theme', next ? 'dark' : 'light');
       html.classList.toggle('dark-mode', next);
+      updateIcon(next);
     });
   })();
 </script>

--- a/writing/index.html
+++ b/writing/index.html
@@ -72,6 +72,12 @@
       gap: 28px;
     }
 
+    .header-controls {
+      display: flex;
+      align-items: center;
+      gap: 28px;
+    }
+
     nav a {
       color: var(--muted);
       text-decoration: none;
@@ -79,9 +85,13 @@
       font-weight: 200;
     }
 
-    nav a:hover,
+    nav a:hover {
+      color: var(--ink);
+    }
+
     nav a.active {
       color: var(--ink);
+      font-weight: 600;
     }
 
     .theme-toggle {
@@ -153,8 +163,8 @@
         padding: 12px 0;
       }
 
-      nav .theme-toggle {
-        margin-top: 8px;
+      .header-controls {
+        gap: 12px;
       }
     }
 
@@ -206,6 +216,7 @@
     .article-list {
       display: flex;
       flex-direction: column;
+      gap: 6px;
     }
 
     .article-item {
@@ -213,7 +224,6 @@
       padding: 24px 16px;
       margin: 0 -16px;
       border-radius: 10px;
-      border-bottom: 1px solid var(--border);
       text-decoration: none;
       color: inherit;
       transition: background-color 0.2s ease;
@@ -221,10 +231,6 @@
 
     .article-item:hover {
       background: rgba(26, 26, 26, 0.05);
-    }
-
-    .article-item:last-child {
-      border-bottom: none;
     }
 
     .article-date {
@@ -253,12 +259,11 @@
       top: 88px;
     }
 
-    .work-sidebar .section-label {
-      font-size: 13px;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      color: var(--muted);
+    .work-heading {
+      font-size: 20px;
+      font-weight: 700;
+      letter-spacing: -0.005em;
+      color: var(--ink);
       margin: 0 0 16px;
     }
 
@@ -350,32 +355,43 @@
       min-width: 0;
     }
 
-    .work-header {
+    .work-company {
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--ink);
+      margin: 0 0 8px;
+    }
+
+    .work-stints {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .work-stint {
       display: flex;
       align-items: baseline;
       justify-content: space-between;
       gap: 12px;
     }
 
-    .work-title {
-      font-size: 16px;
-      font-weight: 600;
-      color: var(--ink);
-      margin: 0;
-    }
-
-    .work-subtitle {
+    .work-role {
       font-size: 14px;
       font-weight: 400;
       color: var(--muted);
-      margin: 3px 0 0;
+      margin: 0;
     }
 
     .work-dates {
-      font-size: 14px;
+      font-size: 13px;
       color: var(--muted);
       white-space: nowrap;
       flex-shrink: 0;
+    }
+
+    .work-dates-current {
+      color: var(--ink);
+      font-weight: 600;
     }
 
     @media (max-width: 800px) {
@@ -435,22 +451,24 @@
     <a href="../index.html" class="brand-name">Austin Edmonson</a>
   </div>
 
-  <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-  </button>
-
-  <nav id="siteNav">
-    <a href="../index.html">Home</a>
+  <div class="header-controls">
+    <nav id="siteNav">
     <a href="index.html" class="active">Articles</a>
     <a href="../about.html">About</a>
     <a href="../projects/index.html">Projects</a>
     <a href="../uses.html">Uses</a>
+    </nav>
+
     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
       </svg>
     </button>
-  </nav>
+
+    <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+  </div>
 </header>
 
 <main>
@@ -462,13 +480,13 @@
       <a href="hexagonal-architecture-didnt-fit.html" class="article-item">
         <p class="article-date">July 2026</p>
         <h2 class="article-title">Why Hexagonal Architecture Didn't Fit My Enterprise Reality</h2>
-        <p class="article-excerpt">Hexagonal, Clean, DDD—the vocabulary assumes one team owns every layer. But when ten teams own ten layers, the pressure you're actually managing is different. And nobody's named it yet.</p>
+        <p class="article-excerpt">Hexagonal, Clean, DDD: the vocabulary assumes one team owns every layer. When ten teams own ten layers, the pressure is different, and nobody's named it yet.</p>
       </a>
 
       <a href="partida-technical-breakdown.html" class="article-item">
         <p class="article-date">July 2026</p>
         <h2 class="article-title">Building Partida: A Technical Breakdown</h2>
-        <p class="article-excerpt">Real bugs, real code, real numbers — the split Base import, the Alembic surprise, the enum-as-primary-key that broke at scale.</p>
+        <p class="article-excerpt">Real bugs, real code, real numbers: the split Base import, the Alembic surprise, the enum-as-primary-key that broke at scale.</p>
       </a>
 
       <a href="overengineering-operational-exhaustion.html" class="article-item">
@@ -492,55 +510,53 @@
 
     <div class="work-sidebar">
       <div class="work-card">
-        <p class="section-label">Work</p>
+        <h2 class="work-heading">Work</h2>
         <div class="work-list">
           <div class="work-item">
             <div class="work-logo work-logo-fill">
               <img src="../assets/home-depot-logo.png" alt="The Home Depot" />
             </div>
             <div class="work-body">
-            <div class="work-header">
-              <p class="work-title">The Home Depot</p>
-              <span class="work-dates">2025 — Present</span>
+              <p class="work-company">The Home Depot</p>
+              <div class="work-stints">
+                <div class="work-stint">
+                  <p class="work-role">Senior Software Engineer</p>
+                  <span class="work-dates work-dates-current">2025 - Present</span>
+                </div>
+                <div class="work-stint">
+                  <p class="work-role">Software Engineer I &amp; II</p>
+                  <span class="work-dates">2022 - 2025</span>
+                </div>
+              </div>
             </div>
-            <p class="work-subtitle">Senior Software Engineer</p>
-          </div>
-          </div>
-          <div class="work-item">
-            <div class="work-logo work-logo-fill">
-              <img src="../assets/home-depot-logo.png" alt="The Home Depot" />
-            </div>
-            <div class="work-body">
-            <div class="work-header">
-              <p class="work-title">The Home Depot</p>
-              <span class="work-dates">2022 — 2025</span>
-            </div>
-            <p class="work-subtitle">Software Engineer I &amp; II</p>
-          </div>
           </div>
           <div class="work-item">
             <div class="work-logo work-logo-fill">
               <img src="../assets/acoustic-ai-logo.jpeg" alt="Acoustic AI" />
             </div>
             <div class="work-body">
-            <div class="work-header">
-              <p class="work-title">Acoustic AI</p>
-              <span class="work-dates">2020</span>
+              <p class="work-company">Acoustic AI</p>
+              <div class="work-stints">
+                <div class="work-stint">
+                  <p class="work-role">Systems Engineer</p>
+                  <span class="work-dates">2020</span>
+                </div>
+              </div>
             </div>
-            <p class="work-subtitle">Systems Engineer</p>
-          </div>
           </div>
           <div class="work-item">
             <div class="work-logo work-logo-img">
               <img src="../assets/shadow-soft-logo.png" alt="Shadow Soft" />
             </div>
             <div class="work-body">
-            <div class="work-header">
-              <p class="work-title">Shadow Soft</p>
-              <span class="work-dates">2019 — 2020</span>
+              <p class="work-company">Shadow Soft</p>
+              <div class="work-stints">
+                <div class="work-stint">
+                  <p class="work-role">DevOps Intern</p>
+                  <span class="work-dates">2019 - 2020</span>
+                </div>
+              </div>
             </div>
-            <p class="work-subtitle">DevOps Intern</p>
-          </div>
           </div>
         </div>
         <a href="../assets/Austin-Edmonson-CV-EU.pdf" class="work-cv-button" target="_blank" rel="noopener">
@@ -582,12 +598,22 @@
       return window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
 
-    html.classList.toggle('dark-mode', isDark());
+    var sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+    var moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+
+    function updateIcon(dark) {
+      toggle.innerHTML = dark ? moonIcon : sunIcon;
+    }
+
+    var dark = isDark();
+    html.classList.toggle('dark-mode', dark);
+    updateIcon(dark);
 
     toggle.addEventListener('click', function() {
       var next = !html.classList.contains('dark-mode');
       localStorage.setItem('theme', next ? 'dark' : 'light');
       html.classList.toggle('dark-mode', next);
+      updateIcon(next);
     });
   })();
 </script>

--- a/writing/llm-non-determinism.html
+++ b/writing/llm-non-determinism.html
@@ -72,6 +72,12 @@
       gap: 28px;
     }
 
+    .header-controls {
+      display: flex;
+      align-items: center;
+      gap: 28px;
+    }
+
     nav a {
       color: var(--muted);
       text-decoration: none;
@@ -79,9 +85,13 @@
       font-weight: 200;
     }
 
-    nav a:hover,
+    nav a:hover {
+      color: var(--ink);
+    }
+
     nav a.active {
       color: var(--ink);
+      font-weight: 600;
     }
 
     .theme-toggle {
@@ -153,8 +163,8 @@
         padding: 12px 0;
       }
 
-      nav .theme-toggle {
-        margin-top: 8px;
+      .header-controls {
+        gap: 12px;
       }
     }
 
@@ -195,8 +205,8 @@
     }
 
     .post-back:hover {
-      color: var(--ink);
-      border-color: var(--ink);
+      color: #EC4899;
+      border-color: #EC4899;
     }
 
     .post-title {
@@ -218,8 +228,25 @@
       width: 100%;
       max-height: 320px;
       object-fit: cover;
-      border-radius: 12px;
+      border-radius: 16px;
       margin-top: 32px;
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      .post-title,
+      .post-date,
+      .post-hero {
+        animation: post-rise 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+      }
+
+      .post-title { animation-delay: 0s; }
+      .post-date { animation-delay: 0.08s; }
+      .post-hero { animation-delay: 0.16s; }
+    }
+
+    @keyframes post-rise {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: translateY(0); }
     }
 
     .post-body {
@@ -338,28 +365,30 @@
     <a href="../index.html" class="brand-name">Austin Edmonson</a>
   </div>
 
-  <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-  </button>
-
-  <nav id="siteNav">
-    <a href="../index.html">Home</a>
+  <div class="header-controls">
+    <nav id="siteNav">
     <a href="index.html" class="active">Articles</a>
     <a href="../about.html">About</a>
     <a href="../projects/index.html">Projects</a>
     <a href="../uses.html">Uses</a>
+    </nav>
+
     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
       </svg>
     </button>
-  </nav>
+
+    <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+  </div>
 </header>
 
 <main>
-  <a href="index.html" class="post-back">←</a>
+  <a href="index.html" class="post-back" aria-label="Back to articles">←</a>
   <h1 class="post-title">LLMs and Non-Determinism in Engineering</h1>
-  <p class="post-date">June 2026</p>
+  <p class="post-date">June 2026 · 2 min read</p>
 
   <img src="../assets/llm-non-determinism-hero.jpg" alt="Abstract illustration of wavy blue and white bands with node points and connecting curves, evoking a data or vector field" class="post-hero" />
 
@@ -427,12 +456,22 @@
       return window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
 
-    html.classList.toggle('dark-mode', isDark());
+    var sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+    var moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+
+    function updateIcon(dark) {
+      toggle.innerHTML = dark ? moonIcon : sunIcon;
+    }
+
+    var dark = isDark();
+    html.classList.toggle('dark-mode', dark);
+    updateIcon(dark);
 
     toggle.addEventListener('click', function() {
       var next = !html.classList.contains('dark-mode');
       localStorage.setItem('theme', next ? 'dark' : 'light');
       html.classList.toggle('dark-mode', next);
+      updateIcon(next);
     });
   })();
 </script>

--- a/writing/overengineering-operational-exhaustion.html
+++ b/writing/overengineering-operational-exhaustion.html
@@ -72,6 +72,12 @@
       gap: 28px;
     }
 
+    .header-controls {
+      display: flex;
+      align-items: center;
+      gap: 28px;
+    }
+
     nav a {
       color: var(--muted);
       text-decoration: none;
@@ -79,9 +85,13 @@
       font-weight: 200;
     }
 
-    nav a:hover,
+    nav a:hover {
+      color: var(--ink);
+    }
+
     nav a.active {
       color: var(--ink);
+      font-weight: 600;
     }
 
     .theme-toggle {
@@ -153,8 +163,8 @@
         padding: 12px 0;
       }
 
-      nav .theme-toggle {
-        margin-top: 8px;
+      .header-controls {
+        gap: 12px;
       }
     }
 
@@ -195,8 +205,8 @@
     }
 
     .post-back:hover {
-      color: var(--ink);
-      border-color: var(--ink);
+      color: #EC4899;
+      border-color: #EC4899;
     }
 
     .post-title {
@@ -218,8 +228,25 @@
       width: 100%;
       max-height: 320px;
       object-fit: cover;
-      border-radius: 12px;
+      border-radius: 16px;
       margin-top: 32px;
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      .post-title,
+      .post-date,
+      .post-hero {
+        animation: post-rise 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+      }
+
+      .post-title { animation-delay: 0s; }
+      .post-date { animation-delay: 0.08s; }
+      .post-hero { animation-delay: 0.16s; }
+    }
+
+    @keyframes post-rise {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: translateY(0); }
     }
 
     .post-body {
@@ -338,28 +365,30 @@
     <a href="../index.html" class="brand-name">Austin Edmonson</a>
   </div>
 
-  <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-  </button>
-
-  <nav id="siteNav">
-    <a href="../index.html">Home</a>
+  <div class="header-controls">
+    <nav id="siteNav">
     <a href="index.html" class="active">Articles</a>
     <a href="../about.html">About</a>
     <a href="../projects/index.html">Projects</a>
     <a href="../uses.html">Uses</a>
+    </nav>
+
     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
       </svg>
     </button>
-  </nav>
+
+    <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+  </div>
 </header>
 
 <main>
-  <a href="index.html" class="post-back">←</a>
+  <a href="index.html" class="post-back" aria-label="Back to articles">←</a>
   <h1 class="post-title">We Were Overengineering Ourselves Into Operational Exhaustion</h1>
-  <p class="post-date">May 2026</p>
+  <p class="post-date">May 2026 · 3 min read</p>
 
   <img src="../assets/overengineering-hero.jpg" alt="A circular hole cut through a grassy hill, opening onto a blue sky with clouds" class="post-hero" />
 
@@ -534,12 +563,22 @@
       return window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
 
-    html.classList.toggle('dark-mode', isDark());
+    var sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+    var moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+
+    function updateIcon(dark) {
+      toggle.innerHTML = dark ? moonIcon : sunIcon;
+    }
+
+    var dark = isDark();
+    html.classList.toggle('dark-mode', dark);
+    updateIcon(dark);
 
     toggle.addEventListener('click', function() {
       var next = !html.classList.contains('dark-mode');
       localStorage.setItem('theme', next ? 'dark' : 'light');
       html.classList.toggle('dark-mode', next);
+      updateIcon(next);
     });
   })();
 </script>

--- a/writing/partida-technical-breakdown.html
+++ b/writing/partida-technical-breakdown.html
@@ -72,6 +72,12 @@
       gap: 28px;
     }
 
+    .header-controls {
+      display: flex;
+      align-items: center;
+      gap: 28px;
+    }
+
     nav a {
       color: var(--muted);
       text-decoration: none;
@@ -79,9 +85,13 @@
       font-weight: 200;
     }
 
-    nav a:hover,
+    nav a:hover {
+      color: var(--ink);
+    }
+
     nav a.active {
       color: var(--ink);
+      font-weight: 600;
     }
 
     .theme-toggle {
@@ -153,8 +163,8 @@
         padding: 12px 0;
       }
 
-      nav .theme-toggle {
-        margin-top: 8px;
+      .header-controls {
+        gap: 12px;
       }
     }
 
@@ -195,8 +205,8 @@
     }
 
     .post-back:hover {
-      color: var(--ink);
-      border-color: var(--ink);
+      color: #EC4899;
+      border-color: #EC4899;
     }
 
     .post-title {
@@ -218,8 +228,25 @@
       width: 100%;
       max-height: 320px;
       object-fit: cover;
-      border-radius: 12px;
+      border-radius: 16px;
       margin-top: 32px;
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      .post-title,
+      .post-date,
+      .post-hero {
+        animation: post-rise 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+      }
+
+      .post-title { animation-delay: 0s; }
+      .post-date { animation-delay: 0.08s; }
+      .post-hero { animation-delay: 0.16s; }
+    }
+
+    @keyframes post-rise {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: translateY(0); }
     }
 
     .post-body {
@@ -338,28 +365,30 @@
     <a href="../index.html" class="brand-name">Austin Edmonson</a>
   </div>
 
-  <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-  </button>
-
-  <nav id="siteNav">
-    <a href="../index.html">Home</a>
+  <div class="header-controls">
+    <nav id="siteNav">
     <a href="index.html" class="active">Articles</a>
     <a href="../about.html">About</a>
     <a href="../projects/index.html">Projects</a>
     <a href="../uses.html">Uses</a>
+    </nav>
+
     <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
       </svg>
     </button>
-  </nav>
+
+    <button class="nav-toggle" id="navToggle" aria-label="Toggle menu">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+  </div>
 </header>
 
 <main>
-  <a href="index.html" class="post-back">←</a>
+  <a href="index.html" class="post-back" aria-label="Back to articles">←</a>
   <h1 class="post-title">Building Partida: A Technical Breakdown</h1>
-  <p class="post-date">July 2026</p>
+  <p class="post-date">July 2026 · 8 min read</p>
 
   <img src="../assets/partida-technical-breakdown-hero.jpg" alt="Surreal collage of a chalk cliff face fitted with windows like an apartment building, overlooking the sea" class="post-hero" />
 
@@ -583,12 +612,22 @@ class HouseholdInvite(Base):
       return window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
 
-    html.classList.toggle('dark-mode', isDark());
+    var sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+    var moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+
+    function updateIcon(dark) {
+      toggle.innerHTML = dark ? moonIcon : sunIcon;
+    }
+
+    var dark = isDark();
+    html.classList.toggle('dark-mode', dark);
+    updateIcon(dark);
 
     toggle.addEventListener('click', function() {
       var next = !html.classList.contains('dark-mode');
       localStorage.setItem('theme', next ? 'dark' : 'light');
       html.classList.toggle('dark-mode', next);
+      updateIcon(next);
     });
   })();
 </script>


### PR DESCRIPTION
- Homepage hero: asymmetric split layout, larger portrait, tightened copy, restrained entrance motion
- Homepage Engineering Impact/Writing/Work sections: replace hairline divider lists with card/spacing-based layouts, promote eyebrow labels to real headings, merge duplicate Home Depot entries in Work
- Roll the same fixes (hairline dividers, eyebrow labels, em-dashes) out to About, Uses, Projects, and the Writing index page for consistency
- Article pages: computed reading time, entrance motion, consistent hover accent, back-link aria-label, 16px hero image radius
- Nav: drop redundant "Home" link, add bold active-page state, move theme toggle out of the mobile dropdown into the header row so it's reachable without opening the menu; toggle now swaps sun/moon icon
- Retire the teal accent in favor of a single pink accent site-wide
- Separate the external-link arrow from tech-stack tags on the Projects page into its own hover-responsive icon
- Correct engineer/repository counts (5,000+ / 52,000+) across homepage, About, and the CI/CD Platform case study